### PR TITLE
One-line installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ GopherSay allow you to display a message said by a cute random Gopher.
 For MacOS:
 
 ```
-brew tap scraly/tools
-brew install gophersay
+brew install scraly/tools/gophersay
 ```
 
 # Pre-requisites


### PR DESCRIPTION
One-line installation

Example on my mac (output)
```
➜ brew install scraly/tools/gophersay
Running `brew update --preinstall`...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
nerdctl
==> Updated Formulae
Updated 4 formulae.
==> Updated Casks
Updated 1 cask.

==> Tapping scraly/tools
Cloning into '/usr/local/Homebrew/Library/Taps/scraly/homebrew-tools'...
remote: Enumerating objects: 18, done.
remote: Counting objects: 100% (18/18), done.
remote: Compressing objects: 100% (15/15), done.
remote: Total 18 (delta 3), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (18/18), done.
Resolving deltas: 100% (3/3), done.
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the scraly/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/scraly/homebrew-tools/gophersay.rb:9

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the scraly/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/scraly/homebrew-tools/tools.rb:9

Tapped 2 formulae (14 files, 11.4KB).
==> Downloading https://github.com/scraly/gophersay/releases/download/v1.0.1/gop
==> Downloading from https://objects.githubusercontent.com/github-production-rel
######################################################################## 100.0%
==> Installing gophersay from scraly/tools
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the scraly/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/scraly/homebrew-tools/gophersay.rb:9

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the scraly/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/scraly/homebrew-tools/gophersay.rb:9

🍺  /usr/local/Cellar/gophersay/1.0.1: 5 files, 1.5MB, built in 9 seconds
==> Running `brew cleanup gophersay`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
~ took 26s
```